### PR TITLE
fix: add root: . to html5validator-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       # Remove it later if you want stricter enforcement.
       - uses: Cyb3r-Jak3/html5validator-action@v7.2.0
         with:
+          root: .
           target: index.html
           extra: --errors-only
 


### PR DESCRIPTION
## Summary

- Adds `root: .` to the `Cyb3r-Jak3/html5validator-action` step in `.github/workflows/ci.yml`
- Resolves the CI failure: `"Need either root or config file"`

The action requires either `root` (the directory to search for HTML files) or a config file. Since `index.html` is at the repository root, `root: .` is the correct value.

## Test plan

- [ ] Verify the `validate-html` job passes on this PR
- [ ] Confirm `check-nav-links` job still passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwsuyxwfMZfKQhT9twfkRY)_